### PR TITLE
Add show title prefix and secondary track info on bottom control panel.

### DIFF
--- a/themes/eole/js/JStheme_common.js
+++ b/themes/eole/js/JStheme_common.js
@@ -530,6 +530,7 @@ function get_colors_global(){
 		colors.wallpaper_overlay_blurred = GetGrey(255,235);
 
 		colors.normal_txt = GetGrey(0);
+        colors.normal_txt_secondary = GetGrey(127);
 		colors.faded_txt = GetGrey(140);
 		colors.superfaded_txt = GetGrey(200);
         colors.full_txt = GetGrey(0);


### PR DESCRIPTION
Add two options to show more info at the Bottom Control Panel.
ShowTitlePrefix: Show %discnumber%.%tracknumber% before the title
ShowTitleSecondary: Show another title format such as original title at the second row.

The progress bar will dynamically position at the center if secondary title format does not exist.