### PR TITLE
Fixed Library Selection Header

### DIFF
--- a/themes/eole/js/WSHplaylistheader.js
+++ b/themes/eole/js/WSHplaylistheader.js
@@ -671,7 +671,7 @@ playlistInfo = function(){
 		this.artists = "";
 		this.albums = "";
 		this.dates = "";
-		this.totalTime = this.plist_items[0].length;
+		this.totalTime = this.plist_items[0].Length;
 
 		all_metas = TF.genre_artist_album_date.EvalWithMetadb(this.plist_items[0]).split(" ^^ ");
 


### PR DESCRIPTION
Fixed incorrect length on totalTime that caused the time to not display correctly on automatic playlists Library Selection and Library Playback 