### PR TITLE
Remove "biography-cache" subfolder for storing images / reviews

### DIFF
--- a/themes/eole/js/biography/scripts/settings.js
+++ b/themes/eole/js/biography/scripts/settings.js
@@ -716,8 +716,8 @@ let settings = [
 	['Auto-Save Folder', '$directory_path(%path%)', 'text', 'foImgCov'],
 	['Auto-Save File Name', 'cover', 'text', 'fnImgCov'],
 
-	['Folder', '%storage_folder%\\biography-cache\\art_img\\$lower($cut(%BIO_ARTIST%,1))\\%BIO_ARTIST%', 'text', 'foCycCov'],
-	['Folder', '%storage_folder%\\biography-cache\\art_img\\$lower($cut(%BIO_ARTIST%,1))\\%BIO_ARTIST%', 'text', 'foCycPhoto'],
+	['Folder', '%storage_folder%\\art_img\\$lower($cut(%BIO_ARTIST%,1))\\%BIO_ARTIST%', 'text', 'foCycCov'],
+	['Folder', '%storage_folder%\\art_img\\$lower($cut(%BIO_ARTIST%,1))\\%BIO_ARTIST%', 'text', 'foCycPhoto'],
 	['Album Name Auto-Clean', false, 'boolean', 'albStrip'],
 	['Cache Expiry (days: minimum 28)', 28, 'num', 'exp'],
 

--- a/themes/eole/js/biography/scripts/settings.js
+++ b/themes/eole/js/biography/scripts/settings.js
@@ -71,8 +71,7 @@ class Settings {
 		this.photoRecycler = `${this.storageFolder}oldPhotosForDeletion\\`;
 		this.settingsKeys = [];
 		
-		this.caPath = `${this.storageFolder}biography-cache`;
-		this.cachePath = `${this.caPath}\\`;
+		this.cachePath = `${this.storageFolder}`;
 		
 		this.suffix = {
 			foLfmRev: ' [Lastfm Review]',


### PR DESCRIPTION
From what I can tell, the biography-cache subfolder doesn't have an apparent purpose for being there, and was introduced at some point during a biography update. This just removes it so the images and reviews are stored in the yttm folder. This fixes issues with the artist images not being displayed as mentioned in #290.

The only point of concern with this change is that existing users will need to modify the biography panel settings to update the path, as it will still look to the "biography-cache" subfolder. This can either be done manually under Server Settings > Photo and Server Settings > Cover, or through resetting the settings to the default which will update the paths to the new one.