### PR TITLE
Fix errors and visuals for multiline track infos

### DIFF
--- a/themes/eole/js/WSHcontrols.js
+++ b/themes/eole/js/WSHcontrols.js
@@ -735,7 +735,7 @@ function get_text(metadb) {
 	
 		if(properties.custom_firstRow=="") {
 			var infos = properties.default_firstRow.Eval();
-			infos = infos.split(" ^^ ");
+			infos = infos.replace(/\r?\n/gm, ' ').split(" ^^ ");
 			g_text_title = infos[1];		
 			if(infos[2]) g_text_artist = " -  "+infos[2];
 			if (properties.showTrackPrefix) g_text_title_prefix = infos[0]+".  ";

--- a/themes/eole/js/WSHgraphicbrowser_trackinfos.js
+++ b/themes/eole/js/WSHgraphicbrowser_trackinfos.js
@@ -4398,7 +4398,7 @@ oBrowser = function(name) {
 						trackinfos = TF.grouping_default_filterbox.EvalWithMetadb(this.list[k]);
 						this.current_grouping = properties.TFgrouping_default;
 					}
-					arr = trackinfos.split(" ^^ ");
+					arr = trackinfos.replace(/\r?\n/gm, ' ').split(" ^^ ");
 					group_string = arr[0]+arr[1];
 				} else {
 					if(properties.SingleMultiDisc) {
@@ -4419,7 +4419,7 @@ oBrowser = function(name) {
 
 				if(i>0) {
 					if(this.custom_groupby) {
-						var groupinfos_rows = TF.grouping.EvalWithMetadb(this.groups[i-1].pl[0]).split(" ^^ ");
+						var groupinfos_rows = TF.grouping.EvalWithMetadb(this.groups[i-1].pl[0]).replace(/\r?\n/gm, ' ').split(" ^^ ");
 						this.groups[i-1].firstRow = groupinfos_rows[0];
 						this.groups[i-1].secondRow = (groupinfos_rows[1]!="")?groupinfos_rows[1]:this.groups[i-1].pl.Count+(this.groups[i-1].pl.Count>1?" tracks":" track");
 					} else {
@@ -4436,7 +4436,7 @@ oBrowser = function(name) {
 
 				if(properties.TFgrouping.length > 0) {
 					groupinfoscustom = TF.groupinfoscustom.EvalWithMetadb(this.list[k]);
-					groupinfoscustom = groupinfoscustom.split(" ^^ ");
+					groupinfoscustom = groupinfoscustom.replace(/\r?\n/gm, ' ').split(" ^^ ");
 					this.groups[i].artist = groupinfoscustom[0];
 					this.groups[i].album = groupinfoscustom[1];
 					this.groups[i].genre = groupinfoscustom[2];
@@ -4444,9 +4444,9 @@ oBrowser = function(name) {
 					this.groups[i].discnb = groupinfoscustom[4];
 					this.groups[i].cachekey = process_cachekey(this.list[k]);
 				} else {
-					if(!this.showFilterBox) arr = trackinfos.split(" ^^ ");
+					if(!this.showFilterBox) arr = trackinfos.replace(/\r?\n/gm, ' ').split(" ^^ ");
 					groupinfos = TF.groupinfos.EvalWithMetadb(this.list[k]);
-					groupinfos = groupinfos.split(" ^^ ");
+					groupinfos = groupinfos.replace(/\r?\n/gm, ' ').split(" ^^ ");
 					this.groups[i].artist = arr[0];
 					this.groups[i].album = arr[1];
 					this.groups[i].genre = groupinfos[0];
@@ -4454,6 +4454,7 @@ oBrowser = function(name) {
 					this.groups[i].discnb = groupinfos[2];
 					this.groups[i].cachekey = process_cachekey(this.list[k],'',groupinfos[3]);
 				}
+				
 				if(this.groups[i].album=="?") this.groups[i].album="Single(s)";
 				if(this.groups[i].artist=="?") this.groups[i].artist="Unknown artist(s)";
 				if(this.groups[i].genre=="?") this.groups[i].genre="";

--- a/themes/eole/js/WSHgraphicbrowser_trackinfos.js
+++ b/themes/eole/js/WSHgraphicbrowser_trackinfos.js
@@ -895,7 +895,7 @@ oRow = function(metadb,itemIndex) {
 			var TagsString = TF.titleB.EvalWithMetadb(metadb);
 		} else
 			var TagsString = TF.title.EvalWithMetadb(metadb);
-		Tags = TagsString.split(" ^^ ");
+		Tags = TagsString.replace(/\r?\n/gm, ' ').split(" ^^ ");
 		
 		this.artist = Tags[0];
 		if(this.artist=="?") this.artist="Unknown artist";

--- a/themes/eole/js/WSHnowplaying.js
+++ b/themes/eole/js/WSHnowplaying.js
@@ -1453,7 +1453,7 @@ function oInfos() {
 			this.getTrackInfosCustom();
 		} else {
 			var defaultinfos = g_tfo.defaultinfos.EvalWithMetadb(this.metadb);
-			defaultinfos = defaultinfos.split(" ^^ ");
+			defaultinfos = defaultinfos.replace(/\r?\n/gm, ' ').split(" ^^ ");
 
 			this.rating = defaultinfos[0];
 

--- a/themes/eole/js/WSHsmoothplaylist_trackinfos.js
+++ b/themes/eole/js/WSHsmoothplaylist_trackinfos.js
@@ -1905,7 +1905,7 @@ oBrowser = function(name) {
         var str_filter = process_string(filter_text);
 		for(var i = 0; i < total; i++) {
 			handle = this.list[i];
-            arr = tf.EvalWithMetadb(handle).split(/ ## (.*)/);
+            arr = tf.EvalWithMetadb(handle).replace(/\r?\n/gm, ' ').split(/ ## ([^]*)/);
             current = arr[0].toLowerCase();
             if(str_filter.length > 0) {
                 var toAdd = match(arr[0]+" "+arr[1], str_filter);
@@ -2512,9 +2512,9 @@ oBrowser = function(name) {
                             // =====
                             // text
                             // =====
+                            
 
-
-							arr_e[2]=arr_e[2].replace(/\s+/g, " ");
+                            arr_e[2]=arr_e[2].replace(/\s+/g, " ");
 							if(!isDefined(this.groups[g].row1_Width)) this.groups[g].row1_Width = gr.CalcTextWidth(this.groups[g].group_header_row_1, g_font.italicplus3);
 							if(!isDefined(this.groups[g].row2_Width)) this.groups[g].row2_Width = gr.CalcTextWidth(this.groups[g].group_header_row_2, g_font.normal);
                             if(!isDefined(this.groups[g].timeWidth)) this.groups[g].timeWidth = gr.CalcTextWidth(this.groups[g].TimeString, ((properties.doubleRowText)?g_font.normal:g_font.min1)) + 10;

--- a/themes/eole/js/WSHsmoothplaylist_trackinfos.js
+++ b/themes/eole/js/WSHsmoothplaylist_trackinfos.js
@@ -2186,18 +2186,18 @@ oBrowser = function(name) {
 					switch(this.rows[i].type) {
 					case this.groupHeaderRowHeight: // last group header row
 						// group tags
-						this.rows[i].groupkey = tf_grp.EvalWithMetadb(this.rows[i].metadb);
+						this.rows[i].groupkey = tf_grp.EvalWithMetadb(this.rows[i].metadb).replace(/\r?\n/mg, ' ');
 						this.rows[i].groupkeysplit = this.rows[i].groupkey.split(" ^^ ");
 						// track tags
-						this.rows[i].infosraw = tf_trk.EvalWithMetadb(this.rows[i].metadb);
+						this.rows[i].infosraw = tf_trk.EvalWithMetadb(this.rows[i].metadb).replace(/\r?\n/mg, ' ');
 						this.rows[i].infos = this.rows[i].infosraw.split(" ^^ ");
 						break;
 					case 0: // track row
 						// group tags
-						this.rows[i].groupkey = tf_grp.EvalWithMetadb(this.rows[i].metadb);
+						this.rows[i].groupkey = tf_grp.EvalWithMetadb(this.rows[i].metadb).replace(/\r?\n/mg, ' ');
 						this.rows[i].groupkeysplit = this.rows[i].groupkey.split(" ^^ ");
 						// track tags
-						this.rows[i].infosraw = tf_trk.EvalWithMetadb(this.rows[i].metadb);
+						this.rows[i].infosraw = tf_trk.EvalWithMetadb(this.rows[i].metadb).replace(/\r?\n/mg, ' ');
 						this.rows[i].infos = this.rows[i].infosraw.split(" ^^ ");
 						break;
 					};
@@ -2209,12 +2209,12 @@ oBrowser = function(name) {
 					switch(this.rows[g_start_].type) {
 					case this.groupHeaderRowHeight: // last group header row
 						// track tags
-						this.rows[g_start_].infosraw = tf_trk.EvalWithMetadb(this.rows[g_start_].metadb);
+						this.rows[g_start_].infosraw = tf_trk.EvalWithMetadb(this.rows[g_start_].metadb).replace(/\r?\n/mg, ' ');
 						this.rows[g_start_].infos = this.rows[g_start_].infosraw.split(" ^^ ");
 						break;
 					case 0: // track row
 						// track tags
-						this.rows[g_start_].infosraw = tf_trk.EvalWithMetadb(this.rows[g_start_].metadb);
+						this.rows[g_start_].infosraw = tf_trk.EvalWithMetadb(this.rows[g_start_].metadb).replace(/\r?\n/mg, ' ');
 						this.rows[g_start_].infos = this.rows[g_start_].infosraw.split(" ^^ ");
 						break;
 					};
@@ -2224,12 +2224,12 @@ oBrowser = function(name) {
                 switch(this.rows[g_end_].type) {
 					case this.groupHeaderRowHeight: // last group header row
 						// track tags
-						this.rows[g_end_].infosraw = tf_trk.EvalWithMetadb(this.rows[g_end_].metadb);
+						this.rows[g_end_].infosraw = tf_trk.EvalWithMetadb(this.rows[g_end_].metadb).replace(/\r?\n/mg, ' ');
 						this.rows[g_end_].infos = this.rows[g_end_].infosraw.split(" ^^ ");
 						break;
 					case 0: // track row
 						// track tags
-						this.rows[g_end_].infosraw = tf_trk.EvalWithMetadb(this.rows[g_end_].metadb);
+						this.rows[g_end_].infosraw = tf_trk.EvalWithMetadb(this.rows[g_end_].metadb).replace(/\r?\n/mg, ' ');
 						this.rows[g_end_].infos = this.rows[g_end_].infosraw.split(" ^^ ");
 						break;
 					};

--- a/themes/eole/js/WSHtitle_bar.js
+++ b/themes/eole/js/WSHtitle_bar.js
@@ -944,7 +944,7 @@ function on_playback_new_track(metadb){
 }
 function eval_caption_title(metadb){
 	if(metadb)
-		caption_title = fb.TitleFormat(properties.tracktitle_format).EvalWithMetadb(metadb);
+		caption_title = fb.TitleFormat(properties.tracktitle_format).EvalWithMetadb(metadb).replace(/\r?\n/gm, ' ');
 }
 function on_playback_stop(reason) {
 	switch(reason) {


### PR DESCRIPTION
Related to issue #309 

I also had track that would crash the UI, but this time the tracks had newlines in the titles, artist fields, etc.

I tried to find most of the places where the UI references the track name and replaced newlines with spaces.
The only thing I didn't check was the Lyrics screen, but when the track has no lyrics, the default text looks fine with the newlines, so I kept it as is.

Here is the before and after of changes
![foobar2000_2024-08-23_18-34-17](https://github.com/user-attachments/assets/548db6e8-e079-4c91-8e95-0ebad87c948a)
![foobar2000_2024-08-23_18-30-57](https://github.com/user-attachments/assets/9ff4d023-fd08-44bc-83c8-07f0c756b049)

The control menu and title bar looked really goofy

Not exactly sure how unusual characters would cause issues here, but could also inspect if provided the audio file