### PR TITLE
Add an option to follow CUI dark/light mode

### DIFF
--- a/themes/eole/js/WSHtitle_bar.js
+++ b/themes/eole/js/WSHtitle_bar.js
@@ -38,6 +38,7 @@ var properties = {
 	wallpaperblurvalue: window.GetProperty("_DISPLAY: Wallpaper Blur Value", 1.05),
 	wallpaperdisplay: window.GetProperty("_DISPLAY: Wallpaper 0=Filling 1=Adjust 2=Stretch", 0),
 	darklayout: window.GetProperty("_DISPLAY: Dark layout", false),
+	darklayout_follow_cui: window.GetProperty("_DISPLAY: Dark layout follow CUI", false),
 	tracktitle_ontop: window.GetProperty("_DISPLAY: Track title", true),
 	tracktitle_format: window.GetProperty("_DISPLAY: Track title format", "[%artist%  -  ][%album%[  -  %tracknumber%] : ]%title%[  -  %date%]"),
 	showRightSidebarBtn: window.GetProperty("_DISPLAY: show right sidebar btn", true),
@@ -1866,6 +1867,9 @@ function draw_main_menu(x,y){
 	control_bar.AppendMenuItem(MF_STRING, 5105, "Adapt colors to Main panel");
 	control_bar.CheckMenuItem(5101+globalProperties.colorsControls, true);
 
+	colors_menu.AppendMenuItem(MF_STRING, 5301, "Follow CUI dark/light mode");
+	colors_menu.CheckMenuItem(5301, properties.darklayout_follow_cui);
+
 	/*appearance_menu.AppendMenuItem(MF_STRING, 4025, "Enable disk cover cache");
 	appearance_menu.CheckMenuItem(4025, globalProperties.enableDiskCache);
 	appearance_menu.AppendMenuItem((globalProperties.enableDiskCache)?MF_STRING:MF_GRAYED, 4023, "Load all covers at startup");
@@ -2275,6 +2279,11 @@ function draw_main_menu(x,y){
 		get_colors();g_searchbox.adapt_look_to_layout();
 		window.Repaint();
         break;
+	case (idx == 5301):
+		properties.darklayout_follow_cui = !properties.darklayout_follow_cui;
+		window.SetProperty("_DISPLAY: Dark layout follow CUI", properties.darklayout_follow_cui);
+		on_colours_changed();
+		break;
     }
 
     basemenu = undefined;
@@ -3009,5 +3018,20 @@ function on_init(){
 			welcome_msg_timer=false;
 		}, 200);
 	}
+	setTimeout(function() {
+		on_colours_changed();
+	}, 100);
 }
 on_init();
+
+function on_colours_changed() {
+	if (!properties.darklayout_follow_cui) return;
+    var col = window.GetColourCUI(3);
+    var r = (col >> 16) & 0xFF;
+    var g = (col >> 8) & 0xFF;
+    var b = col & 0xFF;
+    var cuiDark = r + g + b < 383;
+    if (cuiDark !== properties.darklayout) {
+        Lightswitch(true);
+    }
+}

--- a/themes/eole/js/WSHtitle_bar.js
+++ b/themes/eole/js/WSHtitle_bar.js
@@ -300,7 +300,7 @@ function Lightswitch(switch_all,new_state){
 	switch_all = typeof switch_all !== 'undefined' ? switch_all : false;
 	new_state = typeof new_state !== 'undefined' ? new_state : !properties.darklayout;
 
-	if(layout_state.isEqual(1) && !switch_all){
+	if(layout_state.isEqual(1) || switch_all){
 		if(switch_all) properties.minimode_dark_theme=new_state;
 		else properties.minimode_dark_theme=!properties.minimode_dark_theme;
         window.NotifyOthers("minimode_dark_theme",properties.minimode_dark_theme);

--- a/themes/eole/js/WSHtitle_bar.js
+++ b/themes/eole/js/WSHtitle_bar.js
@@ -3018,9 +3018,7 @@ function on_init(){
 			welcome_msg_timer=false;
 		}, 200);
 	}
-	setTimeout(function() {
-		on_colours_changed();
-	}, 100);
+	setTimeout(on_colours_changed, 100);
 }
 on_init();
 


### PR DESCRIPTION
I noticed that the Columns UI has supported following the system's light and dark color settings in the new version, but the Eole theme does not support this. This experience is somewhat disjointed. This has also be requested formerly in: https://github.com/Ottodix/Eole-foobar-theme/issues/248

Therefore, I added an option "Follow CUI dark/light mode" in the skin settings menu, which can switch the skin's color scheme in real time according to the CUI's settings.

However, since the switching is done using the built-in Lightswitch function, in order to enable the Mini Player mode to also switch light/dark mode normally, I modified the response feature of the Mini Player panel to Lightswitch. Now, when you double-click the LightSwitch button, all panels including Mini Player, will switch their color scheme (previously, the light/dark mode of the Mini Player were independent of the "switch all" operation).